### PR TITLE
Fix de-syncing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-textarea-autosize": "^7.0.4",
     "redux": "^4.0.0",
     "redux-persist": "^5.10.0",
-    "redux-state-sync": "^1.1.1",
+    "redux-state-sync": "^2.0.2",
     "smpte-timecode": "^1.2.1",
     "uuid": "^3.3.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import UninitializedMode from './UninitializedMode';
 const mapStateToProps = state => ({
   time: state.time,
   notes: state.notes,
+  wasReset: state.wasReset,
 });
 
 class App extends Component {
@@ -35,6 +36,12 @@ class App extends Component {
         this.interviewerMode();
       }
     };
+  }
+
+  componentDidUpdate() {
+    if (this.props.wasReset && this.state.mode !== 'uninitializedMode') {
+      this.uninitializedMode();
+    }
   }
 
   uninitializedMode() {

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ class App extends Component {
 
     this.producerMode = this.producerMode.bind(this);
     this.pausedMode = this.pausedMode.bind(this);
+    this.modeChannel = new window.BroadcastChannel('ltc_video_notes_mode_channel');
 
     this.state = {
       mode: 'uninitializedMode',
@@ -28,20 +29,12 @@ class App extends Component {
     if (this.props.time > 0) {
       this.pausedMode();
     }
-  }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.time === 0) {
-      if (this.state.mode !== 'uninitializedMode') {
-        this.uninitializedMode();
-      }
-    }
-
-    else if (prevProps.time === 0 && prevProps.time !== this.props.time) {
-      if (!document.hasFocus()) {
+    this.modeChannel.onmessage = ({data: message}) => {
+      if (message === 'producerMode') {
         this.interviewerMode();
       }
-    }
+    };
   }
 
   uninitializedMode() {
@@ -54,6 +47,8 @@ class App extends Component {
     this.setState({
       mode: 'producerMode',
     });
+
+    this.modeChannel.postMessage('producerMode');
   }
 
   interviewerMode() {

--- a/src/App.js
+++ b/src/App.js
@@ -31,8 +31,16 @@ class App extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if ((this.state.mode === 'pausedMode' || this.state.mode === 'uninitializedMode') && prevProps.time !== this.props.time) {
-      this.interviewerMode();
+    if (this.props.time === 0) {
+      if (this.state.mode !== 'uninitializedMode') {
+        this.uninitializedMode();
+      }
+    }
+
+    else if (prevProps.time === 0 && prevProps.time !== this.props.time) {
+      if (!document.hasFocus()) {
+        this.interviewerMode();
+      }
     }
   }
 

--- a/src/ControlBar.js
+++ b/src/ControlBar.js
@@ -28,8 +28,12 @@ class ControlBar extends Component {
     }
   }
 
-  componentDidMount() {
+  syncAudioWithState() {
     this.audioTag.current.audioEl.currentTime = this.props.time;
+  }
+
+  componentDidMount() {
+    this.syncAudioWithState();
 
     this.timer = window.setTimeout(() => {
       this.setState({
@@ -40,6 +44,12 @@ class ControlBar extends Component {
     this.props.dispatch(
       updateTime(this.props.time)
     );
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.time > this.props.time) {
+      this.syncAudioWithState();
+    }
   }
 
   componentWillUnmount() {

--- a/src/Reset.js
+++ b/src/Reset.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { reset } from './actions';
 
 class Reset extends Component {
   constructor(props) {
@@ -9,8 +11,7 @@ class Reset extends Component {
 
   onClick() {
     if (window.confirm('This deletes all producer and interviewer notes. Make sure you’ve downloaded them if you want them.')) {
-      window.localStorage.clear();
-      window.location.reload();
+      this.props.dispatch(reset());
     }
   }
 
@@ -25,4 +26,4 @@ class Reset extends Component {
   }
 }
 
-export default Reset;
+export default connect()(Reset);

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -35,3 +35,7 @@ export const addNestedProducerNote = (timeStart, timeEnd, note, parentId) => ({
   timeEnd: timeEnd,
   note
 });
+
+export const reset = () => ({
+  type: 'RESET'
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { persistStore, persistReducer } from 'redux-persist';
 import { PersistGate } from 'redux-persist/integration/react';
 import storage from 'redux-persist/lib/storage';
 import { actionStorageMiddleware, createStorageListener } from 'redux-state-sync';
-import rootReducer from './reducers';
+import appReducer from './reducers';
 import App from './App';
 import './index.css';
 
@@ -18,6 +18,14 @@ const persistConfig = {
 const middlewares = [
   actionStorageMiddleware,
 ];
+
+const rootReducer = (state, action) => {
+  if (action.type === 'RESET') {
+    state = undefined;
+  }
+
+  return appReducer(state, action)
+}
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 const store = createStore(persistedReducer, {}, applyMiddleware(...middlewares))

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { createStore, applyMiddleware } from 'redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import { PersistGate } from 'redux-persist/integration/react';
 import storage from 'redux-persist/lib/storage';
-import { actionStorageMiddleware, createStorageListener } from 'redux-state-sync';
+import { createStateSyncMiddleware } from 'redux-state-sync';
 import appReducer from './reducers';
 import App from './App';
 import './index.css';
@@ -15,13 +15,20 @@ const persistConfig = {
   storage,
 };
 
+const syncConfig = {
+  broadcastChannelOption: { type: 'localstorage' },
+};
+
 const middlewares = [
-  actionStorageMiddleware,
+  createStateSyncMiddleware(syncConfig),
 ];
 
 const rootReducer = (state, action) => {
   if (action.type === 'RESET') {
-    state = undefined;
+    state = {
+      time: 0,
+      notes: [],
+    };
   }
 
   return appReducer(state, action)
@@ -39,5 +46,3 @@ render(
   </Provider>,
   document.getElementById('root')
 );
-
-createStorageListener(store);

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,10 @@ const middlewares = [
 
 const rootReducer = (state, action) => {
   if (action.type === 'RESET') {
-    state = {
+    return state = {
       time: 0,
       notes: [],
+      wasReset: true,
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const persistConfig = {
 };
 
 const syncConfig = {
+  channel: 'ltc_video_notes_redux_channel',
   broadcastChannelOption: { type: 'localstorage' },
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,7 +2,10 @@ import { combineReducers } from 'redux';
 import time from './time';
 import notes from './notes';
 
+const wasReset = () => false;
+
 export default combineReducers({
   time,
-  notes
+  notes,
+  wasReset
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,13 @@
     "@babel/types" "7.0.0-beta.51"
     lodash "^4.17.5"
 
+"@babel/runtime@7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
+  integrity sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
@@ -1305,6 +1312,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.16:
+  version "1.6.40"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.40.tgz#02e4cd4d6e266c4d9ece2469c05cb6439149fc78"
+  integrity sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ==
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1403,6 +1415,19 @@ braces@^2.3.0, braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+broadcast-channel@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-2.1.8.tgz#af4cfbf417ce8697c4397857d514ac7fde80306a"
+  integrity sha512-WTJNQ9hQRJRJSZ1sxqSpCjrTmfKq5aoNG5I04x55DBW/IJGQwN1iXrdLzM3+GgYV9pI9M5ZSyhj99uJdM569Eg==
+  dependencies:
+    "@babel/runtime" "7.1.5"
+    detect-node "2.0.4"
+    js-sha3 "0.8.0"
+    microseconds "0.1.0"
+    nano-time "1.0.0"
+    rimraf "2.6.2"
+    unload "2.1.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -2434,6 +2459,11 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
+detect-node@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
 detect-node@^2.0.3:
   version "2.0.3"
@@ -4698,6 +4728,11 @@ js-base64@^2.1.9:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.8.tgz#57a9b130888f956834aa40c5b165ba59c758f033"
   integrity sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5222,6 +5257,11 @@ micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+microseconds@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.1.0.tgz#47dc7bcf62171b8030e2152fd82f12a6894a7119"
+  integrity sha1-R9x7z2IXG4Aw4hUv2C8SpolKcRk=
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -5358,6 +5398,13 @@ nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
   integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6761,10 +6808,12 @@ redux-persist@^5.10.0:
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
   integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
 
-redux-state-sync@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/redux-state-sync/-/redux-state-sync-1.1.1.tgz#e9bd5032e6906055fa99a1efb9403aed13353ed3"
-  integrity sha512-0xy9a0r7C5od8DvkuK1dtXrfQN9mv0JVEzmG7J4QeanTzPMeGLiW75NRJCDRQ+WqcLGiJibsiJkUeTfl/rONLQ==
+redux-state-sync@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/redux-state-sync/-/redux-state-sync-2.0.2.tgz#9d85aee45fed6bcb9172339719d6a0dc9f9e379d"
+  integrity sha512-0CwU7XGWKXkxVNqlSKGkuPMCHRWWz+cK0v5HoV4Pg6qToFz0DuB0aZ2n1EivBQW3Wdi5VTPgei6pi49iMYW0zQ==
+  dependencies:
+    broadcast-channel "^2.1.8"
 
 redux@^4.0.0:
   version "4.0.0"
@@ -7024,7 +7073,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.6.1:
+rimraf@2.6.2, rimraf@^2.2.8, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
@@ -7972,6 +8021,14 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unload@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.1.0.tgz#24e620607fdf1642de9533e4675682b28bdf8394"
+  integrity sha512-vOg/orTFrHv60iWLZbBpgrgoFaSovkcgQJUmBHNGFWlSFdwtoANZaT3uSePVhggkWSsPxs2rpBl5LHpmcSGjRw==
+  dependencies:
+    "@babel/runtime" "7.1.5"
+    detect-node "2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes https://github.com/ehmorris/ltc-video-notes/issues/2.

We're now resetting everything by passing a blank redux state in a new action called reset, instead of resetting by clearing localStorage and reloading the page. This was proposed in [this SO thread](https://stackoverflow.com/a/35641992/9064059).

The manual reset we performed before did not sync across tabs, so additional tabs like the prompt would retain old data and break. Since the new reset is a redux action, it syncs correctly across tabs.

Some additional related changes and benefits:

- Because we're no longer reloading the page, the new uninitialized state animates nicely
- Redux-state-sync is updated to 2.0, and now uses BroadcastChannel
- Interviewer mode is now triggered explicitly by an additional BroadcastChannel, instead of relying on a very fuzzy side-effect of using localStorage to sync the time value across tabs