### PR TITLE
Add a recording start time

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@wootencl/react-textfit": "^1.1.3",
     "emotion": "^9.2.8",
+    "moment": "^2.24.0",
     "react": "^16.5.1",
     "react-audio-player": "^0.10.0",
     "react-dom": "^16.5.1",

--- a/src/ControlBar.js
+++ b/src/ControlBar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { updateTime } from './actions';
+import { updateTime, setMetadata } from './actions';
 import AudioFile from './2_hours_of_silence.ogg';
 import Audio from 'react-audio-player';
 import Clock from './Clock';
@@ -19,6 +19,7 @@ class ControlBar extends Component {
 
     this.onAudioUpdate = this.onAudioUpdate.bind(this);
     this.isLoaded = this.isLoaded.bind(this);
+    this.initialize = this.initialize.bind(this);
     this.play = this.play.bind(this);
     this.pause = this.pause.bind(this);
 
@@ -71,6 +72,11 @@ class ControlBar extends Component {
     );
   }
 
+  initialize () {
+    this.props.dispatch(setMetadata());
+    this.play();
+  }
+
   play () {
     this.audioTag.current.audioEl.play();
   }
@@ -94,7 +100,7 @@ class ControlBar extends Component {
               </WithIndicator>
 
               {this.props.mode === 'uninitializedMode' &&
-                <Button onClick={this.play}>
+                <Button onClick={this.initialize}>
                   Begin Recording
                 </Button>
               }

--- a/src/Download.js
+++ b/src/Download.js
@@ -58,14 +58,8 @@ ${notesToString(this.props.interviewerNotes)}
 
 -----
 
-DEBUG METADATA PLUGINS:
-${this.props.metadata.plugins}
-
-DEBUG METADATA USER AGENT:
+DEBUG USER AGENT:
 ${this.props.metadata.userAgent}
-
-DEBUG METADATA CONNECTION INFO:
-${this.props.metadata.connectionInfo}
 `;
 
     const file = new window.Blob([notes], {

--- a/src/Download.js
+++ b/src/Download.js
@@ -8,6 +8,7 @@ const nonActionNotesByType = (notes, filter) => notes.filter(note => note.type =
 const sortByTimeAsc = (note1, note2) => note1.timeStart - note2.timeStart;
 
 const mapStateToProps = state => ({
+  metadata: state.metadata,
   producerNotes: nonActionNotesByType(state.notes, 'producer').sort(sortByTimeAsc),
   interviewerNotes: nonActionNotesByType(state.notes, 'interviewer').sort(sortByTimeAsc)
 });
@@ -44,11 +45,28 @@ class Download extends Component {
   }
 
   componentDidMount () {
-    const notes = `PRODUCER NOTES:
+    const notes = `NOTES INITIALIZED:
+${this.props.metadata.timeOfDayInitialized}
+
+-----
+
+PRODUCER NOTES:
 ${notesToString(this.props.producerNotes)}
 
 INTERVIEWER NOTES:
-${notesToString(this.props.interviewerNotes)}`;
+${notesToString(this.props.interviewerNotes)}
+
+-----
+
+DEBUG METADATA PLUGINS:
+${this.props.metadata.plugins}
+
+DEBUG METADATA USER AGENT:
+${this.props.metadata.userAgent}
+
+DEBUG METADATA CONNECTION INFO:
+${this.props.metadata.connectionInfo}
+`;
 
     const file = new window.Blob([notes], {
       type: 'text/plain'

--- a/src/Download.js
+++ b/src/Download.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import SMPTETimecode from 'smpte-timecode';
 import styled from 'react-emotion';
+import moment from 'moment';
 
 const nonActionNotesByType = (notes, filter) => notes.filter(note => note.type === filter && !note.action);
 
@@ -23,16 +24,19 @@ const formatTime = (time) => {
   return new SMPTETimecode(dateObject, 23.976).toString();
 };
 
-const formatNote = ({ timeStart, timeEnd, note }) => {
+const formatNote = (timeOfDayInitialized, { timeStart, timeEnd, note }) => {
+  const dateFromTimeStart = moment(timeOfDayInitialized).add(timeStart, 'seconds').format('h:mm:ss');
+  const dateFromTimeEnd = moment(timeOfDayInitialized).add(timeEnd, 'seconds').format('h:mm:ss');
+
   return `
-[${formatTime(timeStart)}]    ${note}
-[${formatTime(timeEnd)}]
+[${formatTime(timeStart)} (${dateFromTimeStart})]    ${note}
+[${formatTime(timeEnd)} (${dateFromTimeEnd})]
 
 `;
 };
 
-const notesToString = (notes) => {
-  return notes.map(note => formatNote(note)).join('');
+const notesToString = (timeOfDayInitialized, notes) => {
+  return notes.map(note => formatNote(timeOfDayInitialized, note)).join('');
 };
 
 class Download extends Component {
@@ -46,15 +50,15 @@ class Download extends Component {
 
   componentDidMount () {
     const notes = `NOTES INITIALIZED:
-${this.props.metadata.timeOfDayInitialized}
+${moment(this.props.metadata.timeOfDayInitialized).format()}
 
 -----
 
 PRODUCER NOTES:
-${notesToString(this.props.producerNotes)}
+${notesToString(this.props.metadata.timeOfDayInitialized, this.props.producerNotes)}
 
 INTERVIEWER NOTES:
-${notesToString(this.props.interviewerNotes)}
+${notesToString(this.props.metadata.timeOfDayInitialized, this.props.interviewerNotes)}
 
 -----
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,7 +1,7 @@
 import uuidv4 from 'uuid/v4';
 
 export const setMetadata = () => {
-  const timeOfDay = new Date(Date.now()).toString();
+  const timeOfDay = new Date(Date.now());
   const userAgent = JSON.stringify(window.navigator.userAgent);
 
   return {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,20 @@
 import uuidv4 from 'uuid/v4';
 
+export const setMetadata = () => {
+  const timeOfDay = new Date(Date.now()).toString();
+  const plugins = JSON.stringify(window.navigator.plugins);
+  const userAgent = JSON.stringify(window.navigator.userAgent);
+  const connectionInfo = JSON.stringify(window.navigator.connection);
+
+  return {
+    type: 'SET_METADATA',
+    timeOfDayInitialized: timeOfDay,
+    plugins: plugins,
+    userAgent: userAgent,
+    connectionInfo: connectionInfo
+  };
+};
+
 export const updateTime = time => ({
   type: 'UPDATE_TIME',
   time

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,16 +2,12 @@ import uuidv4 from 'uuid/v4';
 
 export const setMetadata = () => {
   const timeOfDay = new Date(Date.now()).toString();
-  const plugins = JSON.stringify(window.navigator.plugins);
   const userAgent = JSON.stringify(window.navigator.userAgent);
-  const connectionInfo = JSON.stringify(window.navigator.connection);
 
   return {
     type: 'SET_METADATA',
     timeOfDayInitialized: timeOfDay,
-    plugins: plugins,
     userAgent: userAgent,
-    connectionInfo: connectionInfo
   };
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const middlewares = [
 const rootReducer = (state, action) => {
   if (action.type === 'RESET') {
     state = {
+      metadata: [],
       time: 0,
       notes: [],
       wasReset: true

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
+import metadata from './metadata';
 import time from './time';
 import notes from './notes';
 import wasReset from './wasReset';
 
 export default combineReducers({
+  metadata,
   time,
   notes,
   wasReset

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -1,0 +1,15 @@
+const metadata = (state = [], action) => {
+  switch (action.type) {
+    case 'SET_METADATA':
+      return {
+        timeOfDayInitialized: action.timeOfDayInitialized,
+        plugins: action.plugins,
+        userAgent: action.userAgent,
+        connectionInfo: action.connectionInfo
+      };
+    default:
+      return state;
+  }
+};
+
+export default metadata;

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -3,7 +3,6 @@ const metadata = (state = [], action) => {
     case 'SET_METADATA':
       return {
         timeOfDayInitialized: action.timeOfDayInitialized,
-        plugins: action.plugins,
         userAgent: action.userAgent,
         connectionInfo: action.connectionInfo
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5624,6 +5624,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Closes https://github.com/ehmorris/ltc-video-notes/issues/6.

This does not measure the time elapsed against the recorded start time, it only saves the clock start time so it can be written to the downloaded log.

This allows the notes to be compared against other timecoded files, even if the notes were started out-of-sync with the other timecoded files. Previously, notes and e.g. cameras would have to be turned on simultaneously in order to be synced.

The new download looks like this:

```
NOTES INITIALIZED:
2019-03-18T09:01:55-04:00

-----

PRODUCER NOTES:

[00:00:00:21 (9:01:56)]    Note 1
[00:00:01:15 (9:01:56)]

[00:00:02:13 (9:01:57)]    Note 2
[00:00:03:05 (9:01:58)]

[00:00:03:11 (9:01:58)]    Note 3
[00:00:03:17 (9:01:59)]

INTERVIEWER NOTES:

[00:00:04:17 (9:02:00)]    Prompt 1
[00:00:05:03 (9:02:00)]


[00:00:07:01 (9:02:02)]    Prompt 2
[00:00:07:07 (9:02:02)]

-----

DEBUG USER AGENT:
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36"
```

If a user is in the middle of a saved project, the download may set a clock time at the time of upgrade.